### PR TITLE
Silence elasticsearch deprecation warnings

### DIFF
--- a/dev_utils/docker-compose.yml
+++ b/dev_utils/docker-compose.yml
@@ -236,6 +236,7 @@ services:
       - "9200:9200"
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
+      - ./elasticsearch.yml:/usr/share/elasticsearch/config/elasticsearch.yml
   kibana:
     image: "docker.elastic.co/kibana/kibana:7.16.3"
     ports:

--- a/dev_utils/elasticsearch.yml
+++ b/dev_utils/elasticsearch.yml
@@ -1,0 +1,3 @@
+cluster.name: "docker-cluster"
+network.host: 0.0.0.0
+logger.deprecation.level = warn


### PR DESCRIPTION
Elasticsearch sends out a lot of deprecation warnings, several per second, which makes the docker-compose output unreadable (it's the kibana service that logs them, but they come from elasticsearch). This changes the deprecation logger of elasticsearch so we don't get those messages anymore.